### PR TITLE
Add firmware documentation overview hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Since people have been asking, I accept donations but please remember that I wor
 </p>
 
 
+## Documentation
+
+- Start with the new [firmware overview](./docs/docs/firmware/index.md) when you need a map of the platform, partition layout, or boot flow. It links to the detailed analyses and highlights warnings before you flash anything experimental.
+- For installation specifics, see the [quick start guide](https://jbatonnet.github.io/Rinkhals/guides/rinkhals-quick-start/) and the [installation and firmware updates](https://jbatonnet.github.io/Rinkhals/Rinkhals/installation-and-firmware-updates/) reference.
+
+
 ## Rinkhals installation
 
 > [!WARNING]

--- a/checklist.md
+++ b/checklist.md
@@ -1,6 +1,7 @@
 # Development Checklist
 
 ## Recently Completed
+- [x] Publish firmware documentation overview with links to boot flow, partition, and update analyses
 - [x] Merge Moonraker MMU Ace component into the app package
 - [x] Wire MMU-specific hooks into `kobra.py` (GCode interception, status/print patchers)
 - [x] Update Moonraker launch scripts to deploy the new component and preserve existing debug tools

--- a/concept.md
+++ b/concept.md
@@ -11,3 +11,5 @@ Recent work also closes the loop on tool selection. The bridge now understands b
 With slicer integration tightening, Rinkhals now consumes `MMU_SLICER_TOOL_MAP` payloads from OrcaSlicer/PrusaSlicer whether they emit comma-separated pairs or JSON blobs. Parsed tool names, materials, temperatures, and gate assignments immediately refresh the in-memory model and status event so Moonraker-side previews always mirror the slicer's intent.
 
 To keep the experience trustworthy while new integrations land, we hardened diagnostics that watch for printer-side overrides. Comment-only `printer.custom.cfg` files are now ignored so the UI surfaces warnings only when real tweaks exist, and the new regression test (`pytest files/3-rinkhals/tests/test_ui_diagnostics.py`) makes sure future refactors preserve that signal-to-noise ratio.
+
+The accompanying documentation now features a firmware overview hub that stitches together the boot flow, partitioning strategy, and update pathways. Capturing those guardrails in one place supports the concept's balance between stock reliability and community-driven experimentation.

--- a/docs/docs/firmware/index.md
+++ b/docs/docs/firmware/index.md
@@ -3,4 +3,53 @@ title: Home
 weight: 3
 ---
 
-TODO
+# Firmware documentation overview
+
+This section collects the research that keeps Rinkhals aligned with Anycubic's Kobra-series firmware. Use it as a map before diving into the deeper analyses—each topic below links to the authoritative reference for that slice of the platform.
+
+## Supported firmware releases
+
+Rinkhals tracks the two most recent Anycubic firmware releases for each supported printer whenever possible. Firmware that falls outside that window may still function, but new capabilities and fixes are only validated against the versions listed in the [project README](../../../README.md#rinkhals-installation). When experimenting with older builds, review the release notes and confirm bootloader compatibility before flashing.
+
+## Start here
+
+- **Boot flow & runtime services** — Follow the startup chain from the Rockchip init scripts through Rinkhals' own entrypoint in [File structure](./file-structure.md#kobra-startup-sequence). The same document outlines how Rinkhals layers its overlay filesystem and supervises vendor daemons.
+- **Partition layout & storage strategy** — The A/B partition map, user storage volumes, and overlay mounts described in [File structure](./file-structure.md#partitions) explain how updates are staged and how recovery works.
+- **GoKlipper integration notes** — Rinkhals keeps Anycubic's Go-based Klipper fork in place; [GoKlipper integration](./goklipper.md) summarizes what the vendor binaries provide and how Rinkhals hooks in without breaking stock features.
+
+## Key analyses
+
+### Boot flow deep dive
+- [File structure](./file-structure.md) walks through `/etc/init.d/rcS`, the chained launchers under `/userdata/app`, and the safeguards that restart Anycubic services if Rinkhals fails.
+- [Binary decompilation & patching](./binary-decompilation-and-patching.md) highlights the UI patches and injected entry points that make the Rinkhals touch interface appear alongside the factory menus.
+
+### Partitioning and persistence
+- [File structure](./file-structure.md#partitions) documents each eMMC slice, including the paired `system`, `oem`, and `ac_*` partitions that Rinkhals swaps during upgrades.
+- [Vanilla Klipper coexistence](./vanilla-klipper.md) explains how community configurations can be staged without corrupting Anycubic's persistent data or breaking the A/B update flow.
+
+### Update & IPC pathways
+- [File structure](./file-structure.md#rinkhals-startup-sequence) covers how OTA packages are validated and mounted before Rinkhals hands control back to vendor processes.
+- [MQTT topics](./mqtt.md) and [IPC command reference](./ipc-commands.md) catalogue the channels Rinkhals monitors to track update status, trigger maintenance, and patch telemetry into Moonraker.
+- [MMU Ace bridge](./mmu-ace.md) details the synchronized update events flowing between Anycubic's firmware and Moonraker for multi-material hardware.
+
+## Warnings & best practices
+
+> [!WARNING]
+> Flashing or patching outside the documented workflows can soft-brick the printer. Always verify firmware compatibility, keep a recovery USB handy, and avoid cross-flashing files meant for different Kobra models.
+
+> [!IMPORTANT]
+> The dual-partition layout assumes clean fallbacks. Do not modify `/system_*`, `/oem_*`, or `/ac_*` directly—stage customizations through `/useremain/rinkhals/[VERSION]` or the documented app system so you can roll back safely.
+
+> [!TIP]
+> Capture the contents of `/userdata` before experimenting. Logs from `/useremain/rinkhals/logs` and MQTT traces often make the difference when diagnosing update issues.
+
+## Additional references
+
+- [Binary decompilation & patching](./binary-decompilation-and-patching.md) — UI hooks and binary instrumentation strategies.
+- [GoKlipper integration](./goklipper.md) — How Anycubic's Go-based stack interacts with upstream Klipper.
+- [IPC command reference](./ipc-commands.md) — Internal RPCs exposed by vendor binaries.
+- [MQTT topics](./mqtt.md) — Broker subjects published by Anycubic services.
+- [MMU Ace bridge](./mmu-ace.md) — Detailed MMU event and command mapping.
+- [Vanilla Klipper coexistence](./vanilla-klipper.md) — Guidelines for running community configs alongside Rinkhals.
+
+Use this index as your launchpad when updating or reverse-engineering the platform. If you discover discrepancies, annotate the relevant page so the rest of the ecosystem stays in sync.

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,6 +1,7 @@
 # Roadmap
 
 ## Q2 2025
+- ✅ Publish firmware documentation overview that connects boot flow, partitioning, and update research for contributors
 - Finalize MMU Ace integration in Moonraker with dual-hub support, slicer tool-map ingestion, spool editing, endless-spool and selection bridging, plus dryer control validation on hardware
 - Harden bed mesh calibration automation for KS1 and combo hardware
 - Coordinate MMU Ace status widgets with Fluidd/Mainsail maintainers


### PR DESCRIPTION
## Summary
- replace the firmware landing page with a navigable overview that surfaces boot flow, partitioning, update pathways, and safety warnings
- point the README, roadmap, concept, and checklist at the new documentation so contributors know where to start

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68e111d1c7948321bfdc0fdd0119e9d8